### PR TITLE
ci: fix typo mistake in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@v2
         with:
-          node-version: v2.x
+          deno-version: v2.x
       - name: Install dependencies
         run: deno i
       - name: Setup Pages


### PR DESCRIPTION
Typo after adapting the workflow from https://github.com/neoncitylights/node/blob/main/.github/workflows/docs.yml